### PR TITLE
refactor(github): 移除日期格式化相关代码

### DIFF
--- a/src/models/platform/github/app.ts
+++ b/src/models/platform/github/app.ts
@@ -2,6 +2,7 @@ import { capitalize } from 'lodash-es'
 
 import {
   AppRepoMovedMsg,
+  formatDate,
   MissingRepoOwnerOrNameMsg,
   NotAccessTokenMsg,
   NotAppSlugMsg,
@@ -176,8 +177,8 @@ export class App extends GitHubClient {
           repositories_url: res.data.repositories_url,
           permissions: res.data.permissions,
           events: res.data.events,
-          created_at: res.data.created_at,
-          updated_at: res.data.updated_at
+          created_at: this.format ? await formatDate(res.data.created_at) : res.data.created_at,
+          updated_at: this.format ? await formatDate(res.data.updated_at) : res.data.updated_at
         }
         res.data = AppData
       }

--- a/src/models/platform/github/commit.ts
+++ b/src/models/platform/github/commit.ts
@@ -41,7 +41,6 @@ export class Commit extends GitHubClient {
    * - url 仓库URL地址
    * - owner 仓库拥有者
    * - sha 提交的SHA值，如果不提供，则默认获取仓库的默认分支的最新提交信息
-   * - format - 可选，是否格式化提交信息, 默认为false
    * @returns 提交信息
    * @example
    * ```ts
@@ -86,7 +85,6 @@ export class Commit extends GitHubClient {
       }
 
       if (res.data) {
-        const isFormat = options.format ?? this.format
         const message = res.data?.commit?.message ?? ''
         const [title, ...bodyParts] = message.split('\n')
         const CommitData: CommitInfoResponseType = {
@@ -103,7 +101,7 @@ export class Commit extends GitHubClient {
               email: res.data.commit.author.email,
               html_url: res.data.author.html_url,
               type: capitalize(String(res.data.author.type).toLowerCase()),
-              date: isFormat
+              date: this.format
                 ? await formatDate(res.data.commit.author.date)
                 : res.data.commit.author.date
             },
@@ -115,12 +113,12 @@ export class Commit extends GitHubClient {
               email: res.data.commit.committer.email,
               html_url: res.data.committer.html_url,
               type: capitalize(String(res.data.committer.type).toLowerCase()),
-              date: isFormat
+              date: this.format
                 ? await formatDate(res.data.commit.committer.date)
                 : res.data.commit.committer.date
             },
             message: res.data.commit.message,
-            ...(isFormat && {
+            ...(this.format && {
               title,
               body: bodyParts < 0 ? bodyParts.join('\n') : null
             }),
@@ -221,7 +219,6 @@ export class Commit extends GitHubClient {
         case 404:
           throw new Error(NotCommitOrRepoMsg)
       }
-      const isFormat = options?.format ?? this.format
       if (res.data) {
         const CommitData: CommitListResponseType = await Promise.all(res.data.map(async (commit: Record<string, any>): Promise<CommitInfoResponseType> => {
           const [title, ...bodyParts] = commit.commit.message.split('\n')
@@ -239,7 +236,7 @@ export class Commit extends GitHubClient {
                 email: commit.commit.author.email,
                 html_url: commit.author.html_url,
                 type: capitalize(String(commit.author.type).toLowerCase()),
-                date: isFormat
+                date: this.format
                   ? await formatDate(commit.commit.author.date)
                   : commit.commit.author.date
               },
@@ -251,12 +248,12 @@ export class Commit extends GitHubClient {
                 email: commit.commit.committer.email,
                 html_url: commit.committer.html_url,
                 type: capitalize(String(commit.committer.type).toLowerCase()),
-                date: isFormat
+                date: this.format
                   ? await formatDate(commit.commit.committer.date)
                   : commit.commit.committer.date
               },
               message: commit.commit.message,
-              ...(isFormat && {
+              ...(this.format && {
                 title,
                 body: bodyParts.length > 0 ? bodyParts.join('\n') : null
               }),

--- a/src/models/platform/github/issue.ts
+++ b/src/models/platform/github/issue.ts
@@ -119,7 +119,6 @@ export class Issue extends GitHubClient {
           throw new Error(IssueMovedMsg)
       }
       if (res.data) {
-        const isFormat = options.format ?? this.format
         const IssueData: IssueInfoResponseType = {
           id: res.data.id,
           html_url: res.data.html_url,
@@ -172,9 +171,9 @@ export class Issue extends GitHubClient {
                 due_on: res.data.milestone.due_on
               }
             : null,
-          closed_at: isFormat ? await formatDate(res.data.closed_at) : res.data.closed_at,
-          created_at: isFormat ? await formatDate(res.data.created_at) : res.data.created_at,
-          updated_at: isFormat ? await formatDate(res.data.updated_at) : res.data.updated_at
+          closed_at: this.format ? await formatDate(res.data.closed_at) : res.data.closed_at,
+          created_at: this.format ? await formatDate(res.data.created_at) : res.data.created_at,
+          updated_at: this.format ? await formatDate(res.data.updated_at) : res.data.updated_at
         }
         res.data = IssueData
       }

--- a/src/models/platform/github/repo.ts
+++ b/src/models/platform/github/repo.ts
@@ -107,7 +107,6 @@ export class Repo extends GitHubClient {
           throw new Error(NotPerrmissionMsg)
       }
       if (res.data) {
-        const isFormat = options.format ?? this.format
         const RepoData: OrgRepoListResponseType = await Promise.all(
           res.data.map(async (repo: Record<string, any>):Promise<RepoInfoResponseType> => ({
             id: repo.id,
@@ -136,13 +135,13 @@ export class Repo extends GitHubClient {
             forks_count: repo.forks_count,
             open_issues_count: repo.open_issues_count,
             default_branch: repo.default_branch,
-            created_at: isFormat
+            created_at: this.format
               ? await formatDate(repo.created_at)
               : repo.created_at,
-            updated_at: isFormat
+            updated_at: this.format
               ? await formatDate(repo.updated_at)
               : repo.updated_at,
-            pushed_at: isFormat
+            pushed_at: this.format
               ? await formatDate(repo.pushed_at)
               : repo.pushed_at
           }))
@@ -201,7 +200,6 @@ export class Repo extends GitHubClient {
       if (res.statusCode === 401) {
         throw new Error(NotPerrmissionMsg)
       }
-      const isFormat = options?.format ?? this.format
       if (res.data) {
         const RepoData: RepoInfoResponseType[] = await Promise.all(
           res.data.map(async (repo: Record<string, any>): Promise<RepoInfoResponseType> => ({
@@ -231,13 +229,13 @@ export class Repo extends GitHubClient {
             forks_count: repo.forks_count,
             open_issues_count: repo.open_issues_count,
             default_branch: repo.default_branch,
-            created_at: isFormat
+            created_at: this.format
               ? await formatDate(repo.created_at)
               : repo.created_at,
-            updated_at: isFormat
+            updated_at: this.format
               ? await formatDate(repo.updated_at)
               : repo.updated_at,
-            pushed_at: isFormat
+            pushed_at: this.format
               ? await formatDate(repo.pushed_at)
               : repo.pushed_at
           }))
@@ -282,7 +280,6 @@ export class Repo extends GitHubClient {
       }
       if (queryOptions?.page) params.page = queryOptions.page.toString()
 
-      const isFormat = options?.format ?? this.format
       const url = `/users/${username}/repos`
       const res = await this.get(url, params)
 
@@ -322,13 +319,13 @@ export class Repo extends GitHubClient {
             forks_count: repo.forks_count,
             open_issues_count: repo.open_issues_count,
             default_branch: repo.default_branch,
-            created_at: isFormat
+            created_at: this.format
               ? await formatDate(repo.created_at)
               : repo.created_at,
-            updated_at: isFormat
+            updated_at: this.format
               ? await formatDate(repo.updated_at)
               : repo.updated_at,
-            pushed_at: isFormat
+            pushed_at: this.format
               ? await formatDate(repo.pushed_at)
               : repo.pushed_at
 
@@ -348,13 +345,11 @@ export class Repo extends GitHubClient {
    * 权限:
    * - Metadata: Read-only, 如果只获取公开仓库可无需此权限
    * @param options - 仓库信息参数对象，必须包含以下两种组合之一：
-   * - options.url 仓库URL地址
-   * - options.owner 仓库拥有者
-   * - options.repo 仓库名称
-   * url参数和owner、repo参数传入其中的一种
+   * - owner 仓库拥有者
+   * - repo 仓库名称
    * @example
    * ```ts
-   * const repo = await repo.get_repo_info({ url: 'https://github.com/CandriaJS/git-neko-kit' })
+   * const repo = await repo.get_repo_info({ owner: 'owner', repo: 'repo' })
    * console.log(repo)
    * ```
    */
@@ -374,7 +369,6 @@ export class Repo extends GitHubClient {
         case 404:
           throw new Error(NotOrgOrUserMsg)
       }
-      const isFormat = options?.format ?? this.format
       if (res.data) {
         const RepoData: RepoInfoResponseType = {
           id: res.data.id,
@@ -403,13 +397,13 @@ export class Repo extends GitHubClient {
           forks_count: res.data.forks_count,
           open_issues_count: res.data.open_issues_count,
           default_branch: res.data.default_branch,
-          created_at: isFormat
+          created_at: this.format
             ? await formatDate(res.data.created_at)
             : res.data.created_at,
-          updated_at: isFormat
+          updated_at: this.format
             ? await formatDate(res.data.updated_at)
             : res.data.updated_at,
-          pushed_at: isFormat
+          pushed_at: this.format
             ? await formatDate(res.data.pushed_at)
             : res.data.pushed_at
         }
@@ -421,6 +415,19 @@ export class Repo extends GitHubClient {
     }
   }
 
+  /**
+   * 获取仓库语言列表
+   * 权限:
+   * - Metadata: Read-only, 如果只获取公开仓库可无需此权限
+   * @param options - 仓库信息参数对象，必须包含以下两种组合之一：
+   * - owner 仓库拥有者
+   * - repo 仓库名称
+   * @example
+   * ```ts
+   * const repo = await repo.get_repo_languages_list({ owner: 'owner', repo: 'repo' })
+   * console.log(repo)
+   * ```
+   */
   public async get_repo_languages_list (
     options: RepoLanguagesListParamType
   ): Promise<ApiResponseType<RepoLanguagesListResponseType>> {
@@ -490,7 +497,6 @@ export class Repo extends GitHubClient {
       if (res.statusCode === 401) {
         throw new Error(NotPerrmissionMsg)
       }
-      const isFormat = options?.format ?? this.format
       if (res.data) {
         const RepoData: OrgRepoCreateResponseType = {
           id: res.data.id,
@@ -519,13 +525,13 @@ export class Repo extends GitHubClient {
           forks_count: res.data.forks_count,
           open_issues_count: res.data.open_issues_count,
           default_branch: res.data.default_branch,
-          created_at: isFormat
+          created_at: this.format
             ? await formatDate(res.data.created_at)
             : res.data.created_at,
-          updated_at: isFormat
+          updated_at: this.format
             ? await formatDate(res.data.updated_at)
             : res.data.updated_at,
-          pushed_at: isFormat
+          pushed_at: this.format
             ? await formatDate(res.data.pushed_at)
             : res.data.pushed_at
         }
@@ -569,7 +575,6 @@ export class Repo extends GitHubClient {
       if (res.statusCode === 401) {
         throw new Error(NotPerrmissionMsg)
       }
-      const isFormat = options?.format ?? this.format
       if (res.data) {
         const RepoData: OrgRepoCreateResponseType = {
           id: res.data.id,
@@ -598,13 +603,13 @@ export class Repo extends GitHubClient {
           forks_count: res.data.forks_count,
           open_issues_count: res.data.open_issues_count,
           default_branch: res.data.default_branch,
-          created_at: isFormat
+          created_at: this.format
             ? await formatDate(res.data.created_at)
             : res.data.created_at,
-          updated_at: isFormat
+          updated_at: this.format
             ? await formatDate(res.data.updated_at)
             : res.data.updated_at,
-          pushed_at: isFormat
+          pushed_at: this.format
             ? await formatDate(res.data.pushed_at)
             : res.data.pushed_at
         }

--- a/src/types/platform/base.ts
+++ b/src/types/platform/base.ts
@@ -67,9 +67,9 @@ export type RepoParamType = RepoBaseParamType | RepoUrlParamType
 /**
  * 议题参数
  */
-export interface IssueIdParamType {
+export interface IssueNumberParamType {
   /** 问题id */
-  issue_id: number | string;
+  issue_number: number | string;
 }
 
 /**

--- a/src/types/platform/github/commit.ts
+++ b/src/types/platform/github/commit.ts
@@ -1,5 +1,4 @@
 import type {
-  formatParamType,
   RepoParamType,
   ShaParamType
 } from '@/types/platform/base'
@@ -8,8 +7,6 @@ import type { UserInfoResponseType } from '@/types/platform/github/user'
 export interface CommitInfoCommonParamType {
   /** 提交SHA */
   sha?: ShaParamType['sha'];
-  /** 是否格式化消息和日期 */
-  format?: formatParamType['format'];
 }
 
 /** Git提交用户信息 */
@@ -141,8 +138,6 @@ export type CommitListParamType = RepoParamType & {
   per_page?: number;
   /** 要获取的结果页码，默认: 1 */
   page?: number;
-  /** 是否格式化消息和日期 */
-  format?: formatParamType['format'];
 }
 /** 提交列表响应类型 */
 export type CommitListResponseType = CommitInfoResponseType[]

--- a/src/types/platform/github/issue.ts
+++ b/src/types/platform/github/issue.ts
@@ -1,4 +1,4 @@
-import type { formatParamType, IssueIdParamType, RepoBaseParamType } from '@/types/platform/base'
+import type { IssueNumberParamType, RepoBaseParamType } from '@/types/platform/base'
 import type { UserInfoResponseType } from '@/types/platform/github/user'
 
 /** 议题用户信息响应类型 */
@@ -43,16 +43,11 @@ export interface MilestoneType {
 }
 
 /** 议题信息参数类型 */
-export type IssueInfoParamType = RepoBaseParamType & {
-  /** 议题ID */
-  issue_number: IssueIdParamType['issue_id']
-  /** 是否格式化日期时间等 */
-  format: formatParamType['format']
-}
+export type IssueInfoParamType = RepoBaseParamType & IssueNumberParamType
 /** 议题详情响应类型 */
 export interface IssueInfoResponseType {
   /** 议题ID */
-  id: IssueIdParamType['issue_id'];
+  id: IssueNumberParamType['issue_number'];
   /** 议题HTML页面URL */
   html_url: string;
   /** 议题编号 */
@@ -203,7 +198,7 @@ export type CreateIssueResponseType = IssueInfoResponseType
 /** 更新议题参数类型 */
 export interface UpdateIssueParamType extends Omit<CreteIssueParamType, 'title' | 'type'> {
   /** 问题ID */
-  issue_number: IssueIdParamType['issue_id']
+  issue_number: IssueNumberParamType['issue_number']
   /** 问题的名称 */
   title?: string | null
   /** 问题的内容 */
@@ -216,10 +211,7 @@ export interface UpdateIssueParamType extends Omit<CreteIssueParamType, 'title' 
 export type UpdateIssueResponseType = IssueInfoResponseType
 
 /** 打开议题参数类型 */
-export interface OpenIssueParamType extends RepoBaseParamType {
-  /** 议题ID */
-  issue_number: IssueIdParamType['issue_id']
-}
+export type OpenIssueParamType = RepoBaseParamType & IssueNumberParamType
 /** 打开议题响应类型 */
 export type OpenIssueResponseType = IssueInfoResponseType
 
@@ -231,7 +223,7 @@ export type CloseIssueResponseType = IssueInfoResponseType
 /** 锁定议题参数类型 */
 export interface LockIssueParamType extends RepoBaseParamType {
   /** 议题ID */
-  issue_number: IssueIdParamType['issue_id']
+  issue_number: IssueNumberParamType['issue_number']
   /**
    * 锁定原因
    * 可以是以下之一：
@@ -357,7 +349,7 @@ export type IssueCommentListResponseType = IssueCommentInfoResponseType[]
 /** 创建议题评论参数类型 */
 export interface CreteIssueCommentParamType extends RepoBaseParamType {
   /** 议题ID */
-  issue_number: IssueIdParamType['issue_id'];
+  issue_number: IssueNumberParamType['issue_number'];
   /** 评论内容 */
   body: string;
 }
@@ -386,7 +378,7 @@ export interface RemoveIssueCommentResponseType {
 /** 获取子议题列表参数类型 */
 export interface SubIssueListParamType extends RepoBaseParamType {
   /** 议题ID */
-  issue_number: IssueIdParamType['issue_id'];
+  issue_number: IssueNumberParamType['issue_number'];
   /**
    * 每页结果数量
    * @default 30
@@ -404,9 +396,9 @@ export type SubIssueListResponseType = IssueInfoResponseType[]
 /** 添加子议题参数类型 */
 export interface AddSubIssueParamType extends RepoBaseParamType {
   /** 议题ID */
-  issue_number: IssueIdParamType['issue_id'];
+  issue_number: IssueNumberParamType['issue_number'];
   /** * 子议题ID */
-  sub_issue_id: IssueIdParamType['issue_id'];
+  sub_issue_id: IssueNumberParamType['issue_number'];
   /** * 是否替换父议题 */
   replace_parent: boolean;
 }
@@ -416,9 +408,9 @@ export type AddSubIssueResponseType = IssueInfoResponseType
 /** 删除子议题参数类型 */
 export interface RemoveSubIssueParamType extends RepoBaseParamType {
   /** 议题ID */
-  issue_number: IssueIdParamType['issue_id'];
+  issue_number: IssueNumberParamType['issue_number'];
   /** 子议题ID */
-  sub_issue_id: IssueIdParamType['issue_id'];
+  sub_issue_id: IssueNumberParamType['issue_number'];
 }
 /** 删除子议题响应类型 */
 export type RemoveSubIssueResponseType = IssueInfoResponseType
@@ -426,19 +418,19 @@ export type RemoveSubIssueResponseType = IssueInfoResponseType
 /** 重新确定子议题优先级参数类型 */
 export interface ReprioritizeSubIssueParamType extends RepoBaseParamType {
   /** 议题ID */
-  issue_number: IssueIdParamType['issue_id'];
+  issue_number: IssueNumberParamType['issue_number'];
   /** 子议题ID */
-  sub_issue_id: IssueIdParamType['issue_id'];
+  sub_issue_id: IssueNumberParamType['issue_number'];
   /**
    * 要优先排序的子问题的 ID（与 before_id 互斥，只能指定其中一个）
    * 在此 ID 之后放置子问题
    */
-  after_id?: IssueIdParamType['issue_id'];
+  after_id?: IssueNumberParamType['issue_number'];
   /**
    * 要优先排序的子问题的 ID（与 after_id 互斥，只能指定其中一个）
    * 在此 ID 之前放置子问题
    */
-  before_id?: IssueIdParamType['issue_id'];
+  before_id?: IssueNumberParamType['issue_number'];
 }
 /** 重新确定子议题优先级响应类型 */
 export type ReprioritizeSubIssueResponseType = IssueInfoResponseType

--- a/src/types/platform/github/repo.ts
+++ b/src/types/platform/github/repo.ts
@@ -1,5 +1,4 @@
 import type {
-  formatParamType,
   OrgNameParamType,
   RepoBaseParamType,
   RepoOwnerParamType,
@@ -29,15 +28,10 @@ export interface UserByTokenRepoListParamType extends RepoListBaseParamType {
   affiliation?: 'owner' | 'collaborator' | 'organization_member'
   /** 类型，可选all， owner， member， 默认为 all */
   type?: 'all' | 'owner' | 'member'
-  /** 是否格式化日期 */
-  format?: formatParamType['format']
 }
 
 /** 仓库信息请求参数 */
-export type RepoInfoParamType = RepoBaseParamType & {
-  /** 是否格式化日期 */
-  format?: formatParamType['format']
-}
+export type RepoInfoParamType = RepoBaseParamType
 
 /** * 仓库信息 */
 export interface RepoInfoResponseType {
@@ -91,8 +85,6 @@ export interface OrgRepoListParmType extends RepoListBaseParamType {
   org: string
   /** 类型，可选all， public， private， forks， sources， member， 默认为 all */
   type?: 'all' | 'public' | 'private' | 'forks' | 'sources' | 'member'
-  /** 是否格式化日期 */
-  format?: formatParamType['format']
 }
 /**
  * 组织仓库列表响应类型
@@ -116,8 +108,6 @@ export interface OrgRepoCreateParamType extends OrgNameParamType {
   has_wiki?: boolean;
   /** 仓库自动初始化 */
   auto_init?: boolean;
-  /** 是否格式化日期 */
-  format?: formatParamType['format'];
 }
 /** 创建组织仓库响应类型 */
 export type OrgRepoCreateResponseType = RepoInfoResponseType
@@ -133,8 +123,6 @@ export interface UserRepoListParamType extends RepoListBaseParamType {
   username: string
   /** 类型，可选all， owner， member， 默认为 all */
   type?: 'all' | 'owner' | 'member'
-  /** 是否格式化日期 */
-  format?: formatParamType['format']
 }
 /** 用户仓库列表类型 */
 export type UserRepoListType = Array<RepoInfoResponseType & {
@@ -188,8 +176,6 @@ export type CollaboratorParamType = RepoInfoParamType & UserNameParamType & {
    * admin - 拥有仓库的完全控制权，包括更改设置和删除仓库。
    */
   permission?: string;
-  /** 是否格式化日期 */
-  format?: formatParamType['format']
 }
 
 /** 邀请协作者响应类型 */


### PR DESCRIPTION
- 删除了多个文件中与日期格式化相关的代码和参数
- 移除了 formatParamType 的引用
- 调整了部分接口和函数定义，去除了与格式化相关的字段

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

重构 GitHub 平台模型和类型，以消除基于选项的日期格式化，移除 formatParamType，简化接口，并添加一个用于获取仓库语言的新 API 方法。

新特性：
- 添加 `get_repo_languages_list` 方法来检索仓库的语言构成。

增强功能：
- 移除所有基于选项的日期格式化标志和 `formatParamType` 引用，而是使用客户端实例级别的 `format` 属性。
- 通过消除本地 `isFormat` 变量并清理仓库、提交和 issue 上的接口，简化模型实现。
- 将 `IssueIdParamType` 重命名为 `IssueNumberParamType`，并整合 issue 相关的参数类型以使用新的 `IssueNumberParamType`。
- 更新 TypeScript 定义和文档注释，以移除已弃用的 `format` 字段并调整示例。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor GitHub platform models and types to eliminate option-based date formatting, remove formatParamType, streamline interfaces, and add a new API method for fetching repository languages.

New Features:
- Add get_repo_languages_list method to retrieve a repository's language breakdown.

Enhancements:
- Remove all option-based date formatting flags and formatParamType references, using the client's instance-level format property instead.
- Simplify model implementations by eliminating local isFormat variables and cleaning up interfaces across repos, commits, and issues.
- Rename IssueIdParamType to IssueNumberParamType and consolidate issue-related param types to use the new IssueNumberParamType.
- Update TypeScript definitions and documentation comments to remove deprecated format fields and adjust examples.

</details>