### PR TITLE
feat(github): 支持个人令牌和 App 令牌两种登录方式

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,12 +119,20 @@ API 封装进度：
 ### 获取实例
 ```ts
 import Client from "@candriajs/git-neko-kit";
+// App令牌使用
 const options = {
   github: {
     Client_ID: '',
     Client_Secret: '',
     Private_Key: '',
     WebHook_Secret: '', // 可选，如果没设置密钥的话，可以不填
+    format: false  // 是否开启格式化，默认为false, 开启后对日期，提交信息等格式化拆分
+  }
+}
+// 私人令牌使用
+const options = {
+  github: {
+    access_token: '',
     format: false  // 是否开启格式化，默认为false, 开启后对日期，提交信息等格式化拆分
   }
 }
@@ -138,12 +146,22 @@ const gh = git_api.github
 或者
 ```ts
 import { GitHubClient } "@candriajs/git-neko-kit";
+// App令牌使用
 const options = {
-  Client_ID: '',
-  Client_Secret: '',
-  Private_Key: '',
-  WebHook_Secret: '', // 可选，如果没设置密钥的话，可以不填
-  format: false  // 是否开启格式化，默认为false, 开启后对日期，提交信息等格式化拆分
+  github: {
+    Client_ID: '',
+    Client_Secret: '',
+    Private_Key: '',
+    WebHook_Secret: '', // 可选，如果没设置密钥的话，可以不填
+    format: false  // 是否开启格式化，默认为false, 开启后对日期，提交信息等格式化拆分
+  }
+}
+// 私人令牌使用
+const options = {
+  github: {
+    access_token: '',
+    format: false  // 是否开启格式化，默认为false, 开启后对日期，提交信息等格式化拆分
+  }
 }
 const gh = new GitHubClient(options)
 ```

--- a/src/common/errorMsg.ts
+++ b/src/common/errorMsg.ts
@@ -1,4 +1,6 @@
 /** 通用参数验证 */
+export const MissingAppClientMsg = '喵呜~ 当前客户端类型不是App类型, 不支持此操作哦'
+export const MissingAppClientCredentialsMsg = '喵呜~ 应用客户端配置不完整'
 export const MissingRequestPathMsg = '喵呜~ 请求路径不能为空'
 export const MissingClientIDMsg = '喵呜~ 应用客户端ID不能为空'
 export const MissingClientSecretMsg = '喵呜~ 应用客户端ID不能为空'

--- a/src/models/platform/github/commit.ts
+++ b/src/models/platform/github/commit.ts
@@ -29,8 +29,8 @@ export class Commit extends GitHubClient {
   constructor (base: GitHubClient) {
     super(base)
     this.userToken = base.userToken
-    this.ApiUrl = base.ApiUrl
-    this.BaseUrl = base.BaseUrl
+    this.api_url = base.api_url
+    this.base_url = base.base_url
   }
 
   /**

--- a/src/models/platform/github/issue.ts
+++ b/src/models/platform/github/issue.ts
@@ -79,8 +79,8 @@ export class Issue extends GitHubClient {
   constructor (base: GitHubClient) {
     super(base)
     this.userToken = base.userToken
-    this.ApiUrl = base.ApiUrl
-    this.BaseUrl = base.BaseUrl
+    this.api_url = base.api_url
+    this.base_url = base.base_url
   }
 
   /**

--- a/src/models/platform/github/org.ts
+++ b/src/models/platform/github/org.ts
@@ -24,8 +24,8 @@ export class Org extends GitHubClient {
   constructor (base: GitHubClient) {
     super(base)
     this.userToken = base.userToken
-    this.ApiUrl = base.ApiUrl
-    this.BaseUrl = base.BaseUrl
+    this.api_url = base.api_url
+    this.base_url = base.base_url
   }
 
   /**

--- a/src/models/platform/github/pull_request.ts
+++ b/src/models/platform/github/pull_request.ts
@@ -58,8 +58,8 @@ export class Pull_Request extends GitHubClient {
   constructor (base: GitHubClient) {
     super(base)
     this.userToken = base.userToken
-    this.ApiUrl = base.ApiUrl
-    this.BaseUrl = base.BaseUrl
+    this.api_url = base.api_url
+    this.base_url = base.base_url
   }
 
   /**

--- a/src/models/platform/github/release.ts
+++ b/src/models/platform/github/release.ts
@@ -38,8 +38,8 @@ export class Release extends GitHubClient {
   constructor (base: GitHubClient) {
     super(base)
     this.userToken = base.userToken
-    this.ApiUrl = base.ApiUrl
-    this.BaseUrl = base.BaseUrl
+    this.api_url = base.api_url
+    this.base_url = base.base_url
   }
 
   /**

--- a/src/models/platform/github/repo.ts
+++ b/src/models/platform/github/repo.ts
@@ -58,8 +58,8 @@ export class Repo extends GitHubClient {
   constructor (base: GitHubClient) {
     super(base)
     this.userToken = base.userToken
-    this.ApiUrl = base.ApiUrl
-    this.BaseUrl = base.BaseUrl
+    this.api_url = base.api_url
+    this.base_url = base.base_url
   }
 
   /**
@@ -879,7 +879,7 @@ export class Repo extends GitHubClient {
       const { owner, repo } = options
       let default_branch
       try {
-        const github_url = this.BaseUrl + '/' + owner + '/' + repo
+        const github_url = this.base_url + '/' + owner + '/' + repo
         default_branch = await get_remote_repo_default_branch(github_url)
       } catch (error) {
         default_branch = (await this.get_repo_info({ owner, repo })).data.default_branch

--- a/src/models/platform/github/user.ts
+++ b/src/models/platform/github/user.ts
@@ -34,8 +34,8 @@ export class User extends GitHubClient {
   constructor (base: GitHubClient) {
     super(base)
     this.userToken = base.userToken
-    this.ApiUrl = base.ApiUrl
-    this.BaseUrl = base.BaseUrl
+    this.api_url = base.api_url
+    this.base_url = base.base_url
   }
 
   /**
@@ -150,23 +150,20 @@ export class User extends GitHubClient {
   /**
    * 通过访问令牌获取用户信息
    * 权限：无需任何权限
-   * @param options - 访问令牌配置参数对象
-   * - access_token - 访问令牌
    * @example
    * ```ts
-   * const userInfo = await user.get_user_info_by_token({ access_token: 'access_token' })
+   * const userInfo = await user.get_user_info_by_token()
    * console.log(userInfo)
    * ```
    */
-  public async get_user_info_by_auth (options?: UserInfoByAuthParamType):
+  public async get_user_info_by_auth ():
   Promise<ApiResponseType<UserInfoResponseType>> {
-    const token = options?.access_token ?? this.userToken
-    if (!token) {
+    if (!this.userToken) {
       throw new Error(MissingAccessTokenMsg)
     }
     try {
       this.setRequestConfig({
-        token
+        token: this.userToken
       })
       const res = await this.get('/user')
       switch (res.statusCode) {
@@ -201,19 +198,17 @@ export class User extends GitHubClient {
   /**
    * 通过访问令牌获取用户信息
    * 权限：无需任何权限
-   * @deprecated 该方法已过时，请使用get_user_info_by_auth方法
-   * @param options - 访问令牌配置参数对象
-   * - access_token - 访问令牌
+   * @deprecated 该方法已过时，请使用get_user_info_by_auth方法牌
    * @example
    * ```ts
-   * const userInfo = await user.get_user_info_by_token({ access_token: 'access_token' })
+   * const userInfo = await user.get_user_info_by_token()
    * console.log(userInfo)
    * ```
    */
 
-  public async get_user_info_by_token (options?: UserInfoByAuthParamType):
+  public async get_user_info_by_token ():
   Promise<ApiResponseType<UserInfoResponseType>> {
-    return this.get_user_info_by_auth(options)
+    return this.get_user_info_by_auth()
   }
 
   /**
@@ -239,7 +234,7 @@ export class User extends GitHubClient {
         throw new Error(`${OrgNotSupportedMsg}获取贡献日历`)
       }
       this.setRequestConfig({
-        url: this.BaseUrl
+        url: this.base_url
       })
       const res = await this.get(`/${options.username}`, {
         action: 'show',

--- a/src/models/platform/github/webhook.ts
+++ b/src/models/platform/github/webhook.ts
@@ -25,8 +25,8 @@ export class WebHook extends GitHubClient {
   constructor (base: GitHubClient) {
     super(base)
     this.userToken = base.userToken
-    this.ApiUrl = base.ApiUrl
-    this.BaseUrl = base.BaseUrl
+    this.api_url = base.api_url
+    this.base_url = base.base_url
   }
 
   /**

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,9 +1,10 @@
-import type { AppClientType, formatParamType } from '@/types/platform/base'
+import type { AccessTokenClentTYpe, AppClientType, formatParamType } from '@/types/platform/base'
 
 /** GitHub客户端类型 */
-export interface GitHubClientType extends AppClientType {
+export type GitHubBaseClient = AppClientType | AccessTokenClentTYpe
+export type GitHubClientType = GitHubBaseClient & {
   /** 是否格式化 */
-  format?: formatParamType['format']
+  readonly format?: formatParamType['format']
 }
 
 /** 客户端类型 */

--- a/src/types/platform/base.ts
+++ b/src/types/platform/base.ts
@@ -85,14 +85,20 @@ export interface CommentIdParamType {
   comment_id: number | string;
 }
 
-/** App 基础入口类型 */
+/** App 客户端类型 */
 export interface AppClientType {
   /** App Client ID */
-  Client_ID: string
+  Client_ID?: string | null
   /** App Client Secret */
-  Client_Secret: string
+  Client_Secret?: string | null
   /** 私钥内容 */
-  Private_Key: string
+  Private_Key?: string | null
   /** WebHook Secret */
-  WebHook_Secret?: string
+  WebHook_Secret?: string | null
+}
+
+/** 访问令牌客户端类型 */
+export interface AccessTokenClentTYpe {
+  /** 访问令牌 */
+  access_token?: string | null
 }


### PR DESCRIPTION
- 修改了 GitHubClient 类，支持两种登录方式的配置

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

使 GitHubClient 能够使用个人访问令牌或 GitHub App 凭据进行身份验证，添加验证和客户端类型检测，并更新命名约定和类型以反映双重登录支持。

新功能：
- 支持使用个人访问令牌 (ghu_ 或 ghp_) 进行身份验证
- 支持使用 GitHub App 凭据（Client_ID、Client_Secret、Private_Key）进行身份验证
- 添加 is_app_client getter 以区分 App 客户端和令牌客户端
- 添加 is_app_inttalled_in_repo 方法以快速检查 App 在存储库上的安装情况

增强功能：
- 将所有 GitHub 模块中的 BaseUrl/ApiUrl 属性重命名为 base_url/api_url
- 引入 validateAppClient 以强制执行 App 凭据配置的完整性
- 统一请求配置以使用新的 base_url/api_url 属性
- 扩展 generate_jwt 以接受可选的私钥参数
- 将 GitHubClientType 重构为 AppClientType 和 AccessTokenClientType 的联合类型

文档：
- 更新 README，包括 App 凭据和个人令牌模式的使用示例

<details>
<summary>Original summary in English</summary>

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

在 GitHubClient 中启用双重身份验证模式，支持个人访问令牌和 GitHub App 凭据，标准化 URL 命名和请求设置，并提供 App 客户端验证和存储库安装检查的实用程序。

新功能：
- 支持使用个人访问令牌 (ghu_/ghp_) 或 GitHub App 凭据进行身份验证
- 添加 is_app_client getter 和 validateAppClient 以区分和强制执行 App 客户端配置
- 添加 is_app_installed_in_repo 方法以快速检查 App 在存储库上的安装情况

增强功能：
- 将 BaseUrl/ApiUrl 属性重命名为 base_url/api_url，并统一跨模块的请求配置
- 将 GitHubClientType 重构为 AppClientType 和 AccessTokenClientType 的联合类型
- 扩展 generate_jwt 以接受可选的私钥参数，并在 App 流程中强制执行凭据验证
- 引入 MissingAppClientMsg 和 MissingAppClientCredentialsMsg 以提供更清晰的 App 客户端错误信息

文档：
- 更新 README，提供 App 凭据和个人令牌登录方法的使用示例

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable dual authentication modes in GitHubClient by supporting personal access tokens and GitHub App credentials, standardize URL naming and request setup, and provide utilities for App client validation and repository installation checks.

New Features:
- Support authentication using either personal access tokens (ghu_/ghp_) or GitHub App credentials
- Add is_app_client getter and validateAppClient to distinguish and enforce App client configuration
- Add is_app_installed_in_repo method to quickly check App installation on a repository

Enhancements:
- Rename BaseUrl/ApiUrl properties to base_url/api_url and unify request configuration across modules
- Refactor GitHubClientType into a union of AppClientType and AccessTokenClientType
- Extend generate_jwt to accept an optional private key parameter and enforce credential validation in App flows
- Introduce MissingAppClientMsg and MissingAppClientCredentialsMsg for clearer App client errors

Documentation:
- Update README with usage examples for both App credential and personal token login methods

</details>

</details>